### PR TITLE
MetricsBatch is now a struct with an identifier and a slice of reports

### DIFF
--- a/endpoint/disk/disk.go
+++ b/endpoint/disk/disk.go
@@ -50,7 +50,12 @@ type DiskEndpoint struct {
 
 type diskReport struct {
 	Name  string
+	Id    string
 	Batch metrics.MetricBatch
+}
+
+func (r diskReport) BatchId() string {
+	return r.Id
 }
 
 // NewDiskEndpoint creates a new DiskEndpoint and starts a goroutine that cleans up expired reports
@@ -97,6 +102,7 @@ func (ep *DiskEndpoint) Send(report endpoint.EndpointReport) error {
 func (ep *DiskEndpoint) BuildReport(mb metrics.MetricBatch) (endpoint.EndpointReport, error) {
 	return &diskReport{
 		Name:  reportName(ep.clock.Now()),
+		Id:    mb.Id,
 		Batch: mb,
 	}, nil
 }

--- a/endpoint/disk/disk_test.go
+++ b/endpoint/disk/disk_test.go
@@ -45,12 +45,15 @@ func TestDiskEndpoint(t *testing.T) {
 
 	// Test a single report write
 	report1, err := ep.BuildReport(metrics.MetricBatch{
-		metrics.MetricReport{
-			Name:      "int-metric1",
-			StartTime: time.Unix(0, 0),
-			EndTime:   time.Unix(1, 0),
-			Value: metrics.MetricValue{
-				IntValue: 10,
+		Id: "report1",
+		Reports: []metrics.MetricReport{
+			{
+				Name:      "int-metric1",
+				StartTime: time.Unix(0, 0),
+				EndTime:   time.Unix(1, 0),
+				Value: metrics.MetricValue{
+					IntValue: 10,
+				},
 			},
 		},
 	})
@@ -68,17 +71,23 @@ func TestDiskEndpoint(t *testing.T) {
 
 	// Test a second report write
 	report2, err := ep.BuildReport(metrics.MetricBatch{
-		metrics.MetricReport{
-			Name:      "int-metric1",
-			StartTime: time.Unix(2, 0),
-			EndTime:   time.Unix(3, 0),
-			Value: metrics.MetricValue{
-				IntValue: 10,
+		Id: "report2",
+		Reports: []metrics.MetricReport{
+			{
+				Name:      "int-metric1",
+				StartTime: time.Unix(2, 0),
+				EndTime:   time.Unix(3, 0),
+				Value: metrics.MetricValue{
+					IntValue: 10,
+				},
 			},
 		},
 	})
 	if err != nil {
 		t.Fatalf("error building report: %+v", err)
+	}
+	if report2.BatchId() != "report2" {
+		t.Fatalf("expected report batch ID to be 'report2', got: %v", report2.BatchId())
 	}
 	if err := ep.Send(report2); err != nil {
 		t.Fatalf("error sending report: %+v", err)

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -23,7 +23,10 @@ import (
 // consumption by the remote service represented by the Endpoint. A report may contain additional
 // information, such as a unique ID used for deduplication. The Dispatcher handles send failure
 // retries, and may call the Endpoint's Send method multiple times with the same Report instance.
-type EndpointReport interface{}
+type EndpointReport interface {
+	// BatchId returns the original Id field from the metrics.MetricBatch used to create this report.
+	BatchId() string
+}
 
 // Endpoint represents a metric reporting endpoint that the agent reports to. For example, Cloud
 // Service Control or PubSub.

--- a/endpoint/servicecontrol/servicecontrol.go
+++ b/endpoint/servicecontrol/servicecontrol.go
@@ -45,7 +45,12 @@ type ServiceControlEndpoint struct {
 }
 
 type serviceControlReport struct {
+	Id      string
 	Request servicecontrol.ReportRequest
+}
+
+func (r serviceControlReport) BatchId() string {
+	return r.Id
 }
 
 // NewServiceControlEndpoint creates a new ServiceControlEndpoint.
@@ -94,9 +99,9 @@ func (ep *ServiceControlEndpoint) Send(report endpoint.EndpointReport) error {
 }
 
 func (ep *ServiceControlEndpoint) BuildReport(mb metrics.MetricBatch) (endpoint.EndpointReport, error) {
-	ops := make([]*servicecontrol.Operation, len(mb))
-	for i := range mb {
-		m := &mb[i]
+	ops := make([]*servicecontrol.Operation, len(mb.Reports))
+	for i := range mb.Reports {
+		m := &mb.Reports[i]
 		id, err := uuid.NewRandom()
 		if err != nil {
 			return nil, err
@@ -138,6 +143,7 @@ func (ep *ServiceControlEndpoint) BuildReport(mb metrics.MetricBatch) (endpoint.
 	}
 
 	return &serviceControlReport{
+		Id: mb.Id,
 		Request: servicecontrol.ReportRequest{
 			Operations: ops,
 		},

--- a/endpoint/servicecontrol/servicecontrol_test.go
+++ b/endpoint/servicecontrol/servicecontrol_test.go
@@ -67,17 +67,23 @@ func TestServiceControlEndpoint(t *testing.T) {
 	t.Run("Report idempotence", func(t *testing.T) {
 		// Test a single report write
 		report1, err := ep.BuildReport(metrics.MetricBatch{
-			metrics.MetricReport{
-				Name:      "int-metric1",
-				StartTime: time.Unix(0, 0),
-				EndTime:   time.Unix(1, 0),
-				Value: metrics.MetricValue{
-					IntValue: 10,
+			Id: "report1",
+			Reports: []metrics.MetricReport{
+				{
+					Name:      "int-metric1",
+					StartTime: time.Unix(0, 0),
+					EndTime:   time.Unix(1, 0),
+					Value: metrics.MetricValue{
+						IntValue: 10,
+					},
 				},
 			},
 		})
 		if err != nil {
 			t.Fatalf("error building report: %+v", err)
+		}
+		if report1.BatchId() != "report1" {
+			t.Fatalf("expected report batch ID to be 'report1', got: %v", report1.BatchId())
 		}
 		if err := ep.Send(report1); err != nil {
 			t.Fatalf("error sending report: %+v", err)
@@ -97,26 +103,29 @@ func TestServiceControlEndpoint(t *testing.T) {
 	t.Run("Sent contents are correct", func(t *testing.T) {
 		// Test a single report write
 		report1, err := ep.BuildReport(metrics.MetricBatch{
-			metrics.MetricReport{
-				Name:      "int-metric",
-				StartTime: time.Unix(0, 0),
-				EndTime:   time.Unix(1, 0),
-				Value: metrics.MetricValue{
-					IntValue: 10,
+			Id: "report1",
+			Reports: []metrics.MetricReport{
+				{
+					Name:      "int-metric",
+					StartTime: time.Unix(0, 0),
+					EndTime:   time.Unix(1, 0),
+					Value: metrics.MetricValue{
+						IntValue: 10,
+					},
+					BillingName: "com.googleapis/services/test-service/IntMetric",
 				},
-				BillingName: "com.googleapis/services/test-service/IntMetric",
-			},
-			metrics.MetricReport{
-				Name:      "double-metric",
-				StartTime: time.Unix(2, 0),
-				EndTime:   time.Unix(3, 0),
-				Value: metrics.MetricValue{
-					DoubleValue: 20,
+				{
+					Name:      "double-metric",
+					StartTime: time.Unix(2, 0),
+					EndTime:   time.Unix(3, 0),
+					Value: metrics.MetricValue{
+						DoubleValue: 20,
+					},
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+					BillingName: "com.googleapis/services/test-service/DoubleMetric",
 				},
-				Labels: map[string]string{
-					"foo": "bar",
-				},
-				BillingName: "com.googleapis/services/test-service/DoubleMetric",
 			},
 		})
 		if err != nil {

--- a/metrics/report.go
+++ b/metrics/report.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/ubbagent/config"
+	"github.com/google/uuid"
 )
 
 // Report represents an aggregated interval for a unique metric + labels combination.
@@ -39,8 +40,23 @@ type MetricValue struct {
 	DoubleValue float64
 }
 
-// MetricBatch is a collection of MetricReports.
-type MetricBatch []MetricReport
+// MetricBatch is a collection of MetricReports with an identifier.
+type MetricBatch struct {
+	Id string
+	Reports []MetricReport
+}
+
+// NewMetricBatch creates a new MetricBatch with a random, unique identifier.
+func NewMetricBatch(reports []MetricReport) (MetricBatch, error) {
+	var batch MetricBatch
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return batch, err
+	}
+	batch.Id = id.String()
+	batch.Reports = reports
+	return batch, nil
+}
 
 func (mr *MetricReport) Validate(conf *config.Metrics) error {
 	def := conf.GetMetricDefinition(mr.Name)

--- a/sender/dispatcher_test.go
+++ b/sender/dispatcher_test.go
@@ -54,11 +54,14 @@ func (s *mockSender) Close() error {
 
 func TestDispatcher(t *testing.T) {
 	batch := metrics.MetricBatch{
-		{
-			Name:      "int-metric",
-			Value:     metrics.MetricValue{IntValue: 30},
-			StartTime: time.Unix(10, 0),
-			EndTime:   time.Unix(11, 0),
+		Id: "batch",
+		Reports: []metrics.MetricReport{
+			{
+				Name:      "int-metric",
+				Value:     metrics.MetricValue{IntValue: 30},
+				StartTime: time.Unix(10, 0),
+				EndTime:   time.Unix(11, 0),
+			},
 		},
 	}
 

--- a/sender/retry_test.go
+++ b/sender/retry_test.go
@@ -37,6 +37,10 @@ type mockReport struct {
 	Batch metrics.MetricBatch
 }
 
+func (r mockReport) BatchId() string {
+	return r.Batch.Id
+}
+
 type mockEndpoint struct {
 	name      string
 	sendErr   error
@@ -116,33 +120,42 @@ func newMockEndpoint(name string) *mockEndpoint {
 
 func TestRetryingSender(t *testing.T) {
 	batch1 := metrics.MetricBatch{
-		{
-			Name:      "int-metric",
-			Value:     metrics.MetricValue{IntValue: 10},
-			StartTime: time.Unix(0, 0),
-			EndTime:   time.Unix(1, 0),
-		},
-		{
-			Name:      "int-metric",
-			Value:     metrics.MetricValue{IntValue: 20},
-			StartTime: time.Unix(2, 0),
-			EndTime:   time.Unix(3, 0),
+		Id: "batch1",
+		Reports: []metrics.MetricReport{
+			{
+				Name:      "int-metric",
+				Value:     metrics.MetricValue{IntValue: 10},
+				StartTime: time.Unix(0, 0),
+				EndTime:   time.Unix(1, 0),
+			},
+			{
+				Name:      "int-metric",
+				Value:     metrics.MetricValue{IntValue: 20},
+				StartTime: time.Unix(2, 0),
+				EndTime:   time.Unix(3, 0),
+			},
 		},
 	}
-	batch2 := []metrics.MetricReport{
-		{
-			Name:      "int-metric",
-			Value:     metrics.MetricValue{IntValue: 30},
-			StartTime: time.Unix(10, 0),
-			EndTime:   time.Unix(11, 0),
+	batch2 := metrics.MetricBatch{
+		Id: "batch2",
+		Reports: []metrics.MetricReport{
+			{
+				Name:      "int-metric",
+				Value:     metrics.MetricValue{IntValue: 30},
+				StartTime: time.Unix(10, 0),
+				EndTime:   time.Unix(11, 0),
+			},
 		},
 	}
 	batch3 := metrics.MetricBatch{
-		{
-			Name:      "int-metric",
-			Value:     metrics.MetricValue{IntValue: 30},
-			StartTime: time.Unix(20, 0),
-			EndTime:   time.Unix(21, 0),
+		Id: "batch3",
+		Reports: []metrics.MetricReport{
+			{
+				Name:      "int-metric",
+				Value:     metrics.MetricValue{IntValue: 30},
+				StartTime: time.Unix(20, 0),
+				EndTime:   time.Unix(21, 0),
+			},
 		},
 	}
 


### PR DESCRIPTION
Previously MetricsBatch was just a type alias of []MetricReport. By making
it a struct and giving each instance a unique ID, we can better track a
batch's progression through the send pipeline.