### PR TITLE
Adds notion of transient errors.

### DIFF
--- a/endpoint/disk/disk.go
+++ b/endpoint/disk/disk.go
@@ -159,3 +159,7 @@ func isExpired(name string, cutoff time.Time) bool {
 	}
 	return t.Before(cutoff)
 }
+
+func (ep *DiskEndpoint) IsTransient(err error) bool {
+	return true
+}

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -47,4 +47,8 @@ type Endpoint interface {
 	// EmptyReport returns a pointer to an empty EndpointReport structure and is used when loading
 	// previously serialized reports from persistent state.
 	EmptyReport() EndpointReport
+
+	// IsTransient returns true if the given error indicates that the operation failed due to some
+	// transient error and can be retried.
+	IsTransient(error) bool
 }

--- a/endpoint/servicecontrol/servicecontrol.go
+++ b/endpoint/servicecontrol/servicecontrol.go
@@ -151,3 +151,17 @@ func (*ServiceControlEndpoint) EmptyReport() endpoint.EndpointReport {
 func (ep *ServiceControlEndpoint) Close() error {
 	return nil
 }
+
+func (ep *ServiceControlEndpoint) IsTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	ae, ok := err.(*googleapi.Error)
+	if !ok {
+		// Some non-http error (perhaps a connection refused or timeout?)
+		// We'll retry.
+		return true
+	}
+	// Return true if this is an http error with a 5xx code.
+	return ae.Code >= 500 && ae.Code < 600
+}


### PR DESCRIPTION
RetryingSender won't attempt a retry if an Endpoint indicates that an error is not transient. 