### PR TITLE
Introduces the concept of a StatsRecorder to record send results.

### DIFF
--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/ubbagent/persistence"
 	"github.com/GoogleCloudPlatform/ubbagent/pipeline"
 	"github.com/GoogleCloudPlatform/ubbagent/sender"
+	"github.com/GoogleCloudPlatform/ubbagent/stats"
 )
 
 // Build builds pipeline containing a configured Aggregator and all of the resources
@@ -42,11 +43,11 @@ func Build(cfg *config.Config, p persistence.Persistence) (pipeline.Head, error)
 	}
 	senders := make([]sender.Sender, len(endpoints))
 	for i := range endpoints {
-		senders[i] = sender.NewRetryingSender(endpoints[i], p)
+		senders[i] = sender.NewRetryingSender(endpoints[i], p, stats.NewNoopStatsRecorder())
 	}
 	d := sender.NewDispatcher(senders)
 
-	return aggregator.NewAggregator(cfg.Metrics, d, p), nil
+	return aggregator.NewAggregator(cfg.Metrics, d, p, stats.NewNoopStatsRecorder()), nil
 }
 
 func createEndpoints(config *config.Config, agentId string) ([]endpoint.Endpoint, error) {

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -17,10 +17,14 @@ package sender
 import (
 	"github.com/GoogleCloudPlatform/ubbagent/metrics"
 	"github.com/GoogleCloudPlatform/ubbagent/pipeline"
+	"github.com/GoogleCloudPlatform/ubbagent/stats"
 )
 
 // PreparedSend is returned by Sender.Prepare() and is used to execute the actual send.
 type PreparedSend interface {
+	// A PreparedSend is also a stats.ExpectedSend and can be used to register with a StatsRecorder.
+	stats.ExpectedSend
+
 	// Send sends an already-prepared report. This method can still generate an error due to
 	// unforeseen transient problems (such as network or persistence problems).
 	Send() error

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -1,0 +1,38 @@
+package stats
+
+// A StatsRecorder records the result of sending a metrics.MetricBatch to one or more endpoints.
+//
+// A StatsRecorder expects the following flow:
+// 1. The Register method is called immediately prior to performing a send. The method is passed an
+//    ExpectedSend instance, which is likely provided by sender.PreparedSend. The agent's
+//    aggregator.Aggregator instance calls Register.
+// 2. As each handler succeeds or fails in performing its portion of the overall operation, it
+//    registers the result using the SendSucceeded and SendFailed methods. The handlers are most
+//    likely instances of sender.RetryingSender, wrapping endpoints.
+//
+// The batchId value should be set to the value of a MetricsBatch.Id. A handler should most likely
+// be set to the name of an endpoint handling part of the send operation.
+type StatsRecorder interface {
+	Register(send ExpectedSend)
+	SendSucceeded(batchId string, handler string)
+	SendFailed(batchId string, handler string)
+}
+
+// An ExpectedSend represents a report that is about to be sent to 1 or more endpoints. ExpectedSend
+// provides both an identifier and a list of handlers that will carry out the send operation. Each
+// handler is expected to register its ultimate success or failure using the same identifier.
+type ExpectedSend interface {
+	BatchId() string
+	Handlers() []string
+}
+
+type noopStatsRecorder struct{}
+
+// NewNoopStatsRecorder returns a StatsRecorder that does nothing.
+func NewNoopStatsRecorder() StatsRecorder {
+	return &noopStatsRecorder{}
+}
+
+func (*noopStatsRecorder) Register(ExpectedSend)        {}
+func (*noopStatsRecorder) SendSucceeded(string, string) {}
+func (*noopStatsRecorder) SendFailed(string, string)    {}


### PR DESCRIPTION
This change adds the StatsRecorder interface and necessary plumbing in
existing components. An actual StatsRecorder implementation will come
in a follow-up change.

See docs in stats/stats.go for more information about the StatsRecorder
interface and its integration with other components.