### PR TITLE
Removes argentum_metric_id-related code.

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -89,9 +89,6 @@ func (h *Aggregator) AddReport(report metrics.MetricReport) error {
 	if err := report.Validate(h.config); err != nil {
 		return err
 	}
-	if err := report.AssignBillingName(h.config); err != nil {
-		return err
-	}
 	h.closeMutex.RLock()
 	defer h.closeMutex.RUnlock()
 	if h.closed {

--- a/config/config.go
+++ b/config/config.go
@@ -119,7 +119,6 @@ type Metrics struct {
 // MetricDefinition describes a single reportable metric's name and type.
 type MetricDefinition struct {
 	Name        string
-	BillingName string
 	Type        string
 }
 
@@ -247,9 +246,6 @@ func (c *Metrics) Validate() error {
 	for _, def := range c.Definitions {
 		if def.Name == "" {
 			return errors.New("missing metric name")
-		}
-		if def.BillingName == "" {
-			return errors.New(fmt.Sprintf("metric %v: missing billing name", def.Name))
 		}
 		if usedNames[def.Name] {
 			return errors.New(fmt.Sprintf("metric %v: duplicate name: %v", def.Name, def.Name))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,10 +55,8 @@ metrics:
   definitions:
   - name: int-metric
     type: int
-    billingName: com.googleapis/services/test-service/IntMetric
   - name: double-metric
     type: double
-    billingName: com.googleapis/services/test-service/DoubleMetric
 endpoints:
 - name: on_disk
   disk:
@@ -88,12 +86,10 @@ endpoints:
 				{
 					Name:        "int-metric",
 					Type:        "int",
-					BillingName: "com.googleapis/services/test-service/IntMetric",
 				},
 				{
 					Name:        "double-metric",
 					Type:        "double",
-					BillingName: "com.googleapis/services/test-service/DoubleMetric",
 				},
 			},
 		},
@@ -140,10 +136,8 @@ metrics:
   definitions:
   - name: int-metric
     type: int
-    billingName: com.googleapis/services/test-service/IntMetric
   - name: double-metric
     type: double
-    billingName: com.googleapis/services/test-service/DoubleMetric
 endpoints:
 - name: on_disk
   disk:
@@ -185,7 +179,6 @@ func TestConfig_Validate(t *testing.T) {
 			{
 				Name:        "int-metric",
 				Type:        "int",
-				BillingName: "com.googleapis/services/test-service/IntMetric",
 			},
 		},
 	}
@@ -250,7 +243,7 @@ func TestConfig_Validate(t *testing.T) {
 			Endpoints: goodEndpoints,
 			Metrics: &config.Metrics{
 				Definitions: []config.MetricDefinition{
-					{Name: "foo", Type: "foo", BillingName: "com.googleapis/services/test-service/IntMetric"},
+					{Name: "foo", Type: "foo"},
 				},
 			},
 		}
@@ -418,9 +411,9 @@ func TestMetrics_Validate(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		validConfig := config.Metrics{
 			Definitions: []config.MetricDefinition{
-				{Name: "int-metric", Type: "int", BillingName: "com.googleapis/services/test-service/IntMetric"},
-				{Name: "int-metric2", Type: "int", BillingName: "com.googleapis/services/test-service/IntMetric2"},
-				{Name: "double-metric", Type: "double", BillingName: "com.googleapis/services/test-service/DoubleMetric"},
+				{Name: "int-metric", Type: "int"},
+				{Name: "int-metric2", Type: "int"},
+				{Name: "double-metric", Type: "double"},
 			},
 		}
 
@@ -433,9 +426,9 @@ func TestMetrics_Validate(t *testing.T) {
 	t.Run("invalid: duplicate metric", func(t *testing.T) {
 		duplicateName := config.Metrics{
 			Definitions: []config.MetricDefinition{
-				{Name: "int-metric", Type: "int", BillingName: "com.googleapis/services/test-service/IntMetric"},
-				{Name: "int-metric", Type: "int", BillingName: "com.googleapis/services/test-service/IntMetric"},
-				{Name: "double-metric", Type: "double", BillingName: "com.googleapis/services/test-service/DoubleMetric"},
+				{Name: "int-metric", Type: "int"},
+				{Name: "int-metric", Type: "int"},
+				{Name: "double-metric", Type: "double"},
 			},
 		}
 
@@ -448,9 +441,9 @@ func TestMetrics_Validate(t *testing.T) {
 	t.Run("invalid: invalid type", func(t *testing.T) {
 		invalidType := config.Metrics{
 			Definitions: []config.MetricDefinition{
-				{Name: "int-metric", Type: "int", BillingName: "com.googleapis/services/test-service/IntMetric"},
-				{Name: "int-metric2", Type: "foo", BillingName: "com.googleapis/services/test-service/IntMetric2"},
-				{Name: "double-metric", Type: "double", BillingName: "com.googleapis/services/test-service/DoubleMetric"},
+				{Name: "int-metric", Type: "int"},
+				{Name: "int-metric2", Type: "foo"},
+				{Name: "double-metric", Type: "double"},
 			},
 		}
 
@@ -464,16 +457,15 @@ func TestMetrics_Validate(t *testing.T) {
 func TestMetrics_GetMetricDefinition(t *testing.T) {
 	validConfig := config.Metrics{
 		Definitions: []config.MetricDefinition{
-			{Name: "int-metric", Type: "int", BillingName: "com.googleapis/services/test-service/IntMetric"},
-			{Name: "int-metric2", Type: "int", BillingName: "com.googleapis/services/test-service/IntMetric2"},
-			{Name: "double-metric", Type: "double", BillingName: "com.googleapis/services/test-service/DoubleMetric"},
+			{Name: "int-metric", Type: "int"},
+			{Name: "int-metric2", Type: "int"},
+			{Name: "double-metric", Type: "double"},
 		},
 	}
 
 	expected := config.MetricDefinition{
 		Name:        "int-metric2",
 		Type:        "int",
-		BillingName: "com.googleapis/services/test-service/IntMetric2",
 	}
 	actual := validConfig.GetMetricDefinition("int-metric2")
 	if *actual != expected {

--- a/endpoint/servicecontrol/servicecontrol.go
+++ b/endpoint/servicecontrol/servicecontrol.go
@@ -30,7 +30,6 @@ import (
 )
 
 const (
-	billingLabelKey = "cloudbilling.googleapis.com/argentum_metric_id"
 	agentIdLabel    = "goog-ubb-agent-id"
 	timeout         = 60 * time.Second
 )
@@ -110,7 +109,6 @@ func (ep *ServiceControlEndpoint) BuildReport(mb metrics.MetricBatch) (endpoint.
 		value := servicecontrol.MetricValue{
 			StartTime: m.StartTime.UTC().Format(time.RFC3339Nano),
 			EndTime:   m.EndTime.UTC().Format(time.RFC3339Nano),
-			Labels:    map[string]string{billingLabelKey: m.BillingName},
 		}
 		if m.Value.IntValue != 0 {
 			value.Int64Value = &m.Value.IntValue

--- a/endpoint/servicecontrol/servicecontrol_test.go
+++ b/endpoint/servicecontrol/servicecontrol_test.go
@@ -112,7 +112,6 @@ func TestServiceControlEndpoint(t *testing.T) {
 					Value: metrics.MetricValue{
 						IntValue: 10,
 					},
-					BillingName: "com.googleapis/services/test-service/IntMetric",
 				},
 				{
 					Name:      "double-metric",
@@ -124,7 +123,6 @@ func TestServiceControlEndpoint(t *testing.T) {
 					Labels: map[string]string{
 						"foo": "bar",
 					},
-					BillingName: "com.googleapis/services/test-service/DoubleMetric",
 				},
 			},
 		})
@@ -155,9 +153,6 @@ func TestServiceControlEndpoint(t *testing.T) {
 								StartTime:  time.Unix(0, 0).UTC().Format(time.RFC3339Nano),
 								EndTime:    time.Unix(1, 0).UTC().Format(time.RFC3339Nano),
 								Int64Value: &intVal,
-								Labels: map[string]string{
-									"cloudbilling.googleapis.com/argentum_metric_id": "com.googleapis/services/test-service/IntMetric",
-								},
 							},
 						},
 					},
@@ -180,9 +175,6 @@ func TestServiceControlEndpoint(t *testing.T) {
 								StartTime:   time.Unix(2, 0).UTC().Format(time.RFC3339Nano),
 								EndTime:     time.Unix(3, 0).UTC().Format(time.RFC3339Nano),
 								DoubleValue: &doubleVal,
-								Labels: map[string]string{
-									"cloudbilling.googleapis.com/argentum_metric_id": "com.googleapis/services/test-service/DoubleMetric",
-								},
 							},
 						},
 					},

--- a/metrics/report.go
+++ b/metrics/report.go
@@ -26,7 +26,6 @@ import (
 // Report represents an aggregated interval for a unique metric + labels combination.
 type MetricReport struct {
 	Name        string
-	BillingName string
 	StartTime   time.Time
 	EndTime     time.Time
 	Labels      map[string]string
@@ -78,14 +77,5 @@ func (mr *MetricReport) Validate(conf *config.Metrics) error {
 		}
 		break
 	}
-	return nil
-}
-
-func (mr *MetricReport) AssignBillingName(conf *config.Metrics) error {
-	def := conf.GetMetricDefinition(mr.Name)
-	if def == nil {
-		return errors.New(fmt.Sprintf("Unknown metric: %v", mr.Name))
-	}
-	mr.BillingName = def.BillingName
 	return nil
 }


### PR DESCRIPTION
The argentum_metric_id label isn't necessary as long as the service and metric
names follow appropriate conventions. The label is slated for deprecation at
some point in the future.