### PR TITLE
Removes the Sender Prepare/Send split, replacing it with only Send.

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -86,14 +86,14 @@ func newAggregator(metric config.MetricDefinition, bufferTime time.Duration, sen
 // the Aggregator's config object. Two reports can be aggregated if they have the same name, contain
 // the same labels, and don't contain overlapping time ranges denoted by StartTime and EndTme.
 func (h *Aggregator) AddReport(report metrics.MetricReport) error {
-	glog.V(2).Infoln("Aggregator:AddReport()")
+	glog.V(2).Infof("aggregator: received report: %v", report.Name)
 	if err := report.Validate(h.metric); err != nil {
 		return err
 	}
 	h.closeMutex.RLock()
 	defer h.closeMutex.RUnlock()
 	if h.closed {
-		return errors.New("Aggregator: AddReport called on closed aggregator")
+		return errors.New("aggregator: AddReport called on closed aggregator")
 	}
 	msg := addMsg{
 		report: report,
@@ -168,14 +168,14 @@ func (h *Aggregator) loadState() bool {
 		return true
 	}
 	// Some other error loading existing state.
-	panic(fmt.Sprintf("Error loading aggregator state: %+v", err))
+	panic(fmt.Sprintf("error loading aggregator state: %+v", err))
 }
 
 func (h *Aggregator) persistState() {
 	// TODO(volkman): always persist a metric's previous end time, even if no bucket is persisted,
 	// so that the start time of the next report after a restart is validated.
 	if err := h.persistence.Value(h.persistenceName()).Store(h.currentBucket); err != nil {
-		panic(fmt.Sprintf("Error persisting aggregator state: %+v", err))
+		panic(fmt.Sprintf("error persisting aggregator state: %+v", err))
 	}
 }
 
@@ -194,24 +194,22 @@ func (h *Aggregator) pushBucket() {
 		}
 	}
 	if len(finishedReports) > 0 {
-		glog.V(2).Infoln("Aggregator:pushBucket(): sending reports")
-		var reports []metrics.StampedMetricReport
+		if len(finishedReports) == 1 {
+			glog.V(2).Infoln("aggregator: sending 1 report")
+		} else {
+			glog.V(2).Infof("aggregator: sending %v reports", len(finishedReports))
+		}
 		for _, r := range finishedReports {
 			sr, err := metrics.NewStampedMetricReport(r)
 			if err != nil {
 				glog.Errorf("aggregator: error creating stamped report: %+v", err)
 				continue
 			}
-			reports = append(reports, sr)
-		}
-		ps, err := h.sender.Prepare(reports...)
-		if err != nil {
-			glog.Errorf("aggregator: error preparing finished bucket: %+v", err)
-			return
-		}
-		if err := ps.Send(); err != nil {
-			glog.Errorf("aggregator: error sending finished bucket: %+v", err)
-			return
+			err = h.sender.Send(sr)
+			if err != nil {
+				glog.Errorf("aggregator: error sending report: %+v", err)
+				continue
+			}
 		}
 	}
 	h.currentBucket = newBucket(now)
@@ -239,7 +237,7 @@ func (ar *aggregatedReport) accept(mr metrics.MetricReport) (bool, error) {
 		return false, nil
 	}
 	if mr.StartTime.Before(ar.EndTime) {
-		return false, errors.New(fmt.Sprintf("Time conflict: %v < %v", mr.StartTime, ar.EndTime))
+		return false, fmt.Errorf("time conflict: %v < %v", mr.StartTime, ar.EndTime)
 	}
 	// Only one of these values should be non-zero. We rely on prior validation to ensure the proper
 	// value (i.e., the one specified in the MetricDefinition) is provided.

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -15,11 +15,9 @@
 package aggregator
 
 import (
-	"errors"
 	"reflect"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,30 +25,31 @@ import (
 	"github.com/GoogleCloudPlatform/ubbagent/config"
 	"github.com/GoogleCloudPlatform/ubbagent/metrics"
 	"github.com/GoogleCloudPlatform/ubbagent/persistence"
-	"github.com/GoogleCloudPlatform/ubbagent/sender"
 )
-
-type mockPreparedSend struct {
-	ms      *mockSender
-	reports []metrics.StampedMetricReport
-}
-
-func (ps *mockPreparedSend) Send() error {
-	return ps.ms.send(ps.reports...)
-}
 
 type mockSender struct {
 	id        string
-	reports   atomic.Value
+	reports   []metrics.MetricReport // must hold sendMutex to read/write
 	sendMutex sync.Mutex
 	errMutex  sync.Mutex
 	sendErr   error
 	waitChan  chan bool
+	waitDone  chan bool
 	released  bool
 }
 
-func (s *mockSender) Prepare(reports ...metrics.StampedMetricReport) (sender.PreparedSend, error) {
-	return &mockPreparedSend{ms: s, reports: reports}, nil
+func (s *mockSender) Send(report metrics.StampedMetricReport) error {
+	s.sendMutex.Lock()
+	s.reports = append(s.reports, report.MetricReport)
+	if s.waitChan != nil {
+		s.waitChan <- true
+		if <-s.waitDone {
+			s.waitChan = nil
+			s.waitDone = nil
+		}
+	}
+	s.sendMutex.Unlock()
+	return nil
 }
 
 func (s *mockSender) Endpoints() (empty []string) {
@@ -64,62 +63,42 @@ func (s *mockSender) Release() error {
 	return nil
 }
 
-func (s *mockSender) setSendErr(err error) {
-	s.errMutex.Lock()
-	s.sendErr = err
-	s.errMutex.Unlock()
-}
-
-func (s *mockSender) getSendErr() (err error) {
-	s.errMutex.Lock()
-	err = s.sendErr
-	s.errMutex.Unlock()
+func (s *mockSender) getReports() (reports []metrics.MetricReport) {
+	s.sendMutex.Lock()
+	reports = s.reports
+	s.reports = []metrics.MetricReport{}
+	s.sendMutex.Unlock()
 	return
 }
 
-func (s *mockSender) setReports(reports []metrics.MetricReport) {
-	s.reports.Store(reports)
-}
-
-func (s *mockSender) getReports() []metrics.MetricReport {
-	return s.reports.Load().([]metrics.MetricReport)
-}
-
-func (s *mockSender) clearReports() {
-	s.setReports([]metrics.MetricReport{})
-}
-
-func (s *mockSender) send(reports ...metrics.StampedMetricReport) error {
-	s.sendMutex.Lock()
-	var r []metrics.MetricReport
-	for _, sr := range reports {
-		r = append(r, sr.MetricReport)
-	}
-	s.setReports(r)
-	if s.waitChan != nil {
-		s.waitChan <- true
-		s.waitChan = nil
-	}
-	s.sendMutex.Unlock()
-	return s.getSendErr()
-}
-
-func (s *mockSender) doAndWait(t *testing.T, f func()) {
+func (s *mockSender) doAndWait(t *testing.T, expected int, f func()) {
 	waitChan := make(chan bool, 1)
+	waitDone := make(chan bool, 1)
 	s.sendMutex.Lock()
 	s.waitChan = waitChan
+	s.waitDone = waitDone
 	f()
 	s.sendMutex.Unlock()
-	select {
-	case <-waitChan:
-	case <-time.After(5 * time.Second):
-		t.Fatal("doAndWait: nothing happened after 5 seconds")
+	count := 0
+	end := time.Now().Add(5 * time.Second)
+	for {
+		select {
+		case <-waitChan:
+			count += 1
+			if count >= expected {
+				s.waitDone <- true
+				return
+			}
+			s.waitDone <- false
+		case <-time.After(end.Sub(time.Now())):
+			t.Fatal("doAndWait: nothing happened after 5 seconds")
+		}
 	}
 }
 
 func newMockSender(id string) *mockSender {
 	ms := &mockSender{id: id}
-	ms.clearReports()
+	ms.getReports()
 	return ms
 }
 
@@ -187,19 +166,16 @@ func TestNewAggregator(t *testing.T) {
 			t.Fatalf("Expected no reports, got: %+v", reports)
 		}
 
-		// We set a send error on the mock sender to prevent the aggregator from successfully sending
-		// its state at Release. A new aggregator created with the same persistence should start with
-		// the previous state.
-		ms.setSendErr(errors.New("send failure"))
-		a.Release()
+		// Use a new MockClock so that manipulating it doesn't trigger the first aggregator, which is
+		// still running.
+		mockClock = clock.NewMockClock()
+		mockClock.SetNow(time.Unix(0, 0))
 
 		// Construct a new aggregator using the same persistence.
 		a = newAggregator(metric, bufTime, ms, p, mockClock)
 
-		ms.doAndWait(t, func() {
-			ms.setSendErr(nil)
-			mockClock.SetNow(time.Unix(100, 0))
-		})
+		// Release the aggregator so that it flushes all of its current reports.
+		a.Release()
 
 		expected := []metrics.MetricReport{report1, report2}
 		reports = ms.getReports()
@@ -207,8 +183,8 @@ func TestNewAggregator(t *testing.T) {
 			t.Fatalf("Aggregated reports: expected: %+v, got: %+v", expected, reports)
 		}
 
-		ms.setSendErr(errors.New("send failure"))
-		a.Release()
+		mockClock = clock.NewMockClock()
+		mockClock.SetNow(time.Unix(0, 0))
 
 		// Create one more aggregator and ensure it doesn't start with previous state.
 		a = newAggregator(metric, bufTime, ms, p, mockClock)
@@ -217,8 +193,7 @@ func TestNewAggregator(t *testing.T) {
 			t.Fatalf("Unexpected error when adding report: %+v", err)
 		}
 
-		ms.doAndWait(t, func() {
-			ms.setSendErr(nil)
+		ms.doAndWait(t, 1, func() {
 			mockClock.SetNow(time.Unix(200, 0))
 		})
 
@@ -227,7 +202,6 @@ func TestNewAggregator(t *testing.T) {
 		if !equalUnordered(reports, expected) {
 			t.Fatalf("Aggregated reports: expected: %+v, got: %+v", expected, reports)
 		}
-		a.Release()
 	})
 }
 
@@ -259,12 +233,11 @@ func TestAggregator_AddReport(t *testing.T) {
 	}
 	bufTime := 1 * time.Second
 
-	ms := newMockSender("sender")
-	mockClock := clock.NewMockClock()
-
 	// Add a report to a zero-state aggregator
 	t.Run("Zero state", func(t *testing.T) {
+		mockClock := clock.NewMockClock()
 		mockClock.SetNow(time.Unix(0, 0))
+		ms := newMockSender("sender")
 		a := newAggregator(metric, bufTime, ms, persistence.NewMemoryPersistence(), mockClock)
 
 		if err := a.AddReport(metrics.MetricReport{
@@ -277,7 +250,7 @@ func TestAggregator_AddReport(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("Unexpected error when adding report: %+v", err)
 		}
-		ms.doAndWait(t, func() {
+		ms.doAndWait(t, 1, func() {
 			mockClock.SetNow(time.Unix(100, 0))
 		})
 
@@ -300,7 +273,9 @@ func TestAggregator_AddReport(t *testing.T) {
 
 	// Add multiple reports, testing aggregation
 	t.Run("Aggregation", func(t *testing.T) {
+		mockClock := clock.NewMockClock()
 		mockClock.SetNow(time.Unix(0, 0))
+		ms := newMockSender("sender")
 		a := newAggregator(metric, bufTime, ms, persistence.NewMemoryPersistence(), mockClock)
 
 		if err := a.AddReport(metrics.MetricReport{
@@ -323,7 +298,7 @@ func TestAggregator_AddReport(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("Unexpected error when adding report: %+v", err)
 		}
-		ms.doAndWait(t, func() {
+		ms.doAndWait(t, 1, func() {
 			mockClock.SetNow(time.Unix(100, 0))
 		})
 
@@ -346,7 +321,9 @@ func TestAggregator_AddReport(t *testing.T) {
 
 	// Add two reports with the same name but different labels: no aggregation
 	t.Run("Different labels", func(t *testing.T) {
+		mockClock := clock.NewMockClock()
 		mockClock.SetNow(time.Unix(0, 0))
+		ms := newMockSender("sender")
 		a := newAggregator(metric, bufTime, ms, persistence.NewMemoryPersistence(), mockClock)
 
 		if err := a.AddReport(metrics.MetricReport{
@@ -375,7 +352,7 @@ func TestAggregator_AddReport(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("Unexpected error when adding report: %+v", err)
 		}
-		ms.doAndWait(t, func() {
+		ms.doAndWait(t, 2, func() {
 			mockClock.SetNow(time.Unix(100, 0))
 		})
 
@@ -412,7 +389,9 @@ func TestAggregator_AddReport(t *testing.T) {
 
 	// Add a report that fails validation: error
 	t.Run("Report validation error", func(t *testing.T) {
+		mockClock := clock.NewMockClock()
 		mockClock.SetNow(time.Unix(0, 0))
+		ms := newMockSender("sender")
 		a := newAggregator(metric, bufTime, ms, persistence.NewMemoryPersistence(), mockClock)
 
 		if err := a.AddReport(metrics.MetricReport{
@@ -432,7 +411,9 @@ func TestAggregator_AddReport(t *testing.T) {
 
 	// Add a report with a start time less than the last end time: error
 	t.Run("Time conflict", func(t *testing.T) {
+		mockClock := clock.NewMockClock()
 		mockClock.SetNow(time.Unix(0, 0))
+		ms := newMockSender("sender")
 		a := newAggregator(metric, bufTime, ms, persistence.NewMemoryPersistence(), mockClock)
 
 		if err := a.AddReport(metrics.MetricReport{
@@ -452,15 +433,16 @@ func TestAggregator_AddReport(t *testing.T) {
 			Value: metrics.MetricValue{
 				IntValue: 5,
 			},
-		}); err == nil || !strings.Contains(err.Error(), "Time conflict") {
-			t.Fatalf("Expected error containing \"Time conflict\", got: %+v", err)
+		}); err == nil || !strings.Contains(err.Error(), "time conflict") {
+			t.Fatalf("Expected error containing \"time conflict\", got: %+v", err)
 		}
 	})
 
 	// Ensure that the push occurs automatically after a timeout
 	t.Run("Push after timeout", func(t *testing.T) {
-		ms.clearReports()
+		mockClock := clock.NewMockClock()
 		mockClock.SetNow(time.Unix(0, 0))
+		ms := newMockSender("sender")
 		a := newAggregator(metric, bufTime, ms, persistence.NewMemoryPersistence(), mockClock)
 
 		if err := a.AddReport(metrics.MetricReport{
@@ -473,21 +455,68 @@ func TestAggregator_AddReport(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("Unexpected error when adding report: %+v", err)
 		}
+		if err := a.AddReport(metrics.MetricReport{
+			Name:      "int-metric",
+			StartTime: time.Unix(2, 0),
+			EndTime:   time.Unix(3, 0),
+			Value: metrics.MetricValue{
+				IntValue: 10,
+			},
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		}); err != nil {
+			t.Fatalf("Unexpected error when adding report: %+v", err)
+		}
 
-		ms.doAndWait(t, func() {
+		ms.doAndWait(t, 2, func() {
 			mockClock.SetNow(time.Unix(10, 0))
 		})
 
-		if len(ms.getReports()) == 0 {
-			t.Fatal("Expected push after timeout, but sender contains no reports")
+		reports := ms.getReports()
+		if len(reports) != 2 {
+			t.Fatalf("Expected push of 2 reports after timeout, got: %+v", reports)
+		}
+
+		if err := a.AddReport(metrics.MetricReport{
+			Name:      "int-metric",
+			StartTime: time.Unix(4, 0),
+			EndTime:   time.Unix(5, 0),
+			Value: metrics.MetricValue{
+				IntValue: 10,
+			},
+		}); err != nil {
+			t.Fatalf("Unexpected error when adding report: %+v", err)
+		}
+		if err := a.AddReport(metrics.MetricReport{
+			Name:      "int-metric",
+			StartTime: time.Unix(6, 0),
+			EndTime:   time.Unix(7, 0),
+			Value: metrics.MetricValue{
+				IntValue: 10,
+			},
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		}); err != nil {
+			t.Fatalf("Unexpected error when adding report: %+v", err)
+		}
+
+		ms.doAndWait(t, 2, func() {
+			mockClock.SetNow(time.Unix(30, 0))
+		})
+
+		reports = ms.getReports()
+		if len(reports) != 2 {
+			t.Fatalf("Expected push of 2 reports after timeout, got: %+v", reports)
 		}
 	})
 
 	// Ensure that a push happens when the aggregator is Released
 	t.Run("Push after Release", func(t *testing.T) {
-		ms.clearReports()
-		ms.setSendErr(nil)
+		mockClock := clock.NewMockClock()
 		mockClock.SetNow(time.Unix(0, 0))
+		ms := newMockSender("sender")
 		a := newAggregator(metric, bufTime, ms, persistence.NewMemoryPersistence(), mockClock)
 
 		if err := a.AddReport(metrics.MetricReport{

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -19,24 +19,21 @@ import (
 	"github.com/GoogleCloudPlatform/ubbagent/pipeline"
 )
 
-// PreparedSend is returned by Sender.Prepare() and is used to execute the actual send.
-type PreparedSend interface {
-	// Send sends an already-prepared report. This method can still generate an error due to
-	// unforeseen transient problems (such as network or persistence problems).
-	Send() error
-}
-
-// Sender handles sending StampedMetricReport objects to remote endpoints.
-// The Sender interface is split into a prepare step and a send step, similar to a two-phase commit.
-// Sending reports to remote endpoints can involve a pre-processing step which might fail. When
-// fanning out to multiple endpoints, preprocessing errors can be caught prior to actually sending.
+// A Sender handles sending StampedMetricReports to remote endpoints.
 type Sender interface {
 	// Sender is a pipeline.Component.
 	pipeline.Component
 
-	// Prepare prepares one or more reports for sending, and returns a Sender used to execute the
-	// send. Any failure during the preparation step will be returned as an error.
-	Prepare(reports ...metrics.StampedMetricReport) (PreparedSend, error)
+	// Send sends the report downstream. The behavior of the Send operation depends on the type of
+	// sender. Some implementations - the Dispatcher, for instance - simply forward the Send to
+	// subsequent Senders. Others - like the RetryingSender - may queue the report and attempt to
+	// send it at a later time.
+	//
+	// An error indicates that something failed quickly, but it does not
+	// indicate that the operation failed completely (i.e., some senders behind a Dispatcher may have
+	// succeeded). Likewise, the lack of an error response does not indicate that the Send operation
+	// succeeded, due to the asynchronous nature of a RetryingSender.
+	Send(report metrics.StampedMetricReport) error
 
 	// Endpoints returns the transitive list of endpoints that this sender will ultimately send to.
 	Endpoints() []string

--- a/stats/basic.go
+++ b/stats/basic.go
@@ -36,7 +36,7 @@ type Basic struct {
 	current      Snapshot
 }
 
-func (s *Basic) Register(id string, handlers ...string) {
+func (s *Basic) Register(id string, handlers []string) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	s.pendingCount++

--- a/stats/basic_test.go
+++ b/stats/basic_test.go
@@ -27,7 +27,7 @@ func TestSimple(t *testing.T) {
 
 	mc.SetNow(time.Unix(1000, 0))
 
-	s.Register("report1", "handler1", "handler2")
+	s.Register("report1", []string{"handler1", "handler2"})
 	s.SendSucceeded("report1", "handler1")
 	s.SendSucceeded("report1", "handler2")
 
@@ -44,7 +44,7 @@ func TestSimple(t *testing.T) {
 
 	mc.SetNow(time.Unix(1100, 0))
 
-	s.Register("report2", "handler1", "handler2", "handler3")
+	s.Register("report2", []string{"handler1", "handler2", "handler3"})
 	s.SendSucceeded("report2", "handler1")
 
 	// There's still one handler remaining, so the stats should not have updated yet.
@@ -83,7 +83,7 @@ func TestSimple(t *testing.T) {
 		t.Fatalf("snap.TotalFailureCount: want=%v, got=%v", want, got)
 	}
 
-	s.Register("report3", "handler1", "handler2")
+	s.Register("report3", []string{"handler1", "handler2"})
 	s.SendSucceeded("report3", "handler1")
 	s.SendSucceeded("report3", "handler2")
 
@@ -101,7 +101,7 @@ func TestSimple(t *testing.T) {
 
 	// Test that the pending set gets trimmed to MAX_PENDING.
 	for i := 0; i < *maxPendingSends+10; i++ {
-		s.Register(fmt.Sprintf("report%v", i), "handler1", "handler2")
+		s.Register(fmt.Sprintf("report%v", i), []string{"handler1", "handler2"})
 		s.SendSucceeded("report3", "handler1")
 	}
 

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -19,17 +19,17 @@ import "time"
 // A Recorder records the result of sending a metrics.StampedMetricReport to one or more endpoints.
 //
 // A Recorder expects the following flow:
-// 1. The Register method is called immediately prior to performing a send. The method is passed an
-//    ExpectedSend instance, which is likely provided by sender.PreparedSend. The agent's
-//    aggregator.Aggregator instance calls Register.
+// 1. The Register method is called prior to performing a send. The method is passed the ID of the
+//    StampedMetricReport being sent and a list of the handlers that will perform the operation.
+//    Register is called by the first Sender in a pipeline, generally a sender.Dispatcher.
 // 2. As each handler succeeds or fails in performing its portion of the overall operation, it
-//    registers the result using the SendSucceeded and SendFailed methods. The handlers are most
-//    likely instances of sender.RetryingSender, wrapping endpoints.
+//    registers the result using the SendSucceeded and SendFailed methods. The handlers are
+//    generally instances of sender.RetryingSender, wrapping endpoints.
 //
-// The id value should be set to the value of a StampedMetricReport.Id. A handler should most
-// likely be set to the name of an endpoint handling part of the send operation.
+// The id value should be set to the value of a StampedMetricReport.Id. A handler should generally
+// be set to the name of an endpoint handling part of the send operation.
 type Recorder interface {
-	Register(id string, handlers ...string)
+	Register(id string, handlers []string)
 	SendSucceeded(id string, handler string)
 	SendFailed(id string, handler string)
 }
@@ -59,6 +59,6 @@ func NewNoopRecorder() Recorder {
 
 type noopRecorder struct{}
 
-func (*noopRecorder) Register(string, ...string)   {}
+func (*noopRecorder) Register(string, []string)    {}
 func (*noopRecorder) SendSucceeded(string, string) {}
 func (*noopRecorder) SendFailed(string, string)    {}


### PR DESCRIPTION
The original idea behind Prepare was to give a chance for Dispatcher to
abort sending to all endpoints if one endpoint generated an early
failure (for example, it failed to render an EndpointReport for some
reason).

This added unnecessary complexity. Instead, we should just try to send
to as many endpoints as possible while also registering failures when
not all are successful.

Sender now just has a single Send method which takes a single report. If
a call to Send results in 1 endpoint failing to render the report, but
two others succeeding, the report will be received by two endpoints but
the agent will register a failure.