### PR TITLE
Adds a sidecar Dockerfile and startup script.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.FROM golang:1.9.2-alpine3.7 AS build
+
+FROM golang:1.9.2-alpine3.7 AS build
+
+COPY . /ubbagent-src/
+WORKDIR /ubbagent-src/
+
+RUN apk add --no-cache make git
+RUN make clean setup deps build
+
+FROM alpine:3.7
+RUN apk add --update libintl ca-certificates && \
+    apk add --virtual build_deps gettext && \
+    cp /usr/bin/envsubst /usr/local/bin/envsubst && \
+    apk del build_deps && \
+    rm -rf /var/cache/apk/*
+
+COPY --from=build /ubbagent-src/bin/ubbagent /usr/local/bin/ubbagent
+COPY docker/ubbagent-start /usr/local/bin/ubbagent-start
+CMD ["/usr/local/bin/ubbagent-start"]

--- a/README.md
+++ b/README.md
@@ -100,3 +100,22 @@ curl http://localhost:3456/status
 
 # Design
 See [DESIGN.md](doc/DESIGN.md).
+
+# Kubernetes
+The easiest way to deploy the metering agent into a Kubernetes cluster is as
+a sidecar container alongside the software being metered. A Dockerfile is
+provided that builds such a container. It accepts the following parameters
+as environment variables:
+
+* `AGENT_CONFIG_FILE` - Required. The path to a file containing the agent's
+configuration.
+* `AGENT_STATE_DIR` - Optional. The path under which the agent stores state.
+If this parameter is not specified, no state will be stored.
+* `AGENT_LOCAL_PORT` - Optional. The pod-local port on which the agent's
+HTTP API will listen for reports and provide status. If this parameter
+is not specified, the agent will not start its HTTP server.
+
+The configuration file is run through envsubst, so it can contain
+any additional parameters as well. For example, a service account
+key and a servicecontrol consumerId may be stored in a Kubernetes
+secret and passed in as environment variables.

--- a/docker/ubbagent-start
+++ b/docker/ubbagent-start
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.FROM golang:1.9.2-alpine3.7 AS build
+
+set -e
+
+if [ -z "$AGENT_CONFIG_FILE" ]; then
+  echo "AGENT_CONFIG_FILE environment variable must be set"
+  exit 1
+fi
+
+if [ -z "$AGENT_STATE_DIR" ]; then
+  STATE="--no-state"
+else
+  STATE="--state-dir=$AGENT_STATE_DIR"
+fi
+
+if [ -z "$AGENT_LOCAL_PORT" ]; then
+  HTTP="--no-http"
+else
+  HTTP="--local-port=$AGENT_LOCAL_PORT"
+fi
+
+cat "$AGENT_CONFIG_FILE" | envsubst > /tmp/ubbagent-envsubst.yaml
+exec ubbagent \
+  --config /tmp/ubbagent-envsubst.yaml \
+  "$STATE" \
+  "$HTTP" \
+  --logtostderr --v=2


### PR DESCRIPTION
When run as a sidecar container, the following env vars are used:

AGENT_CONFIG_FILE - Required. The path to a file containing the agent's
configuration.

AGENT_STATE_DIR - Optional. The path under which the agent stores state.
If this parameter is not specified, no state will be stored.

AGENT_LOCAL_PORT - Optional. The pod-local port on which the agent's
HTTP API will listen for reports and provide status. If this parameter
is not specified, the agent will not start its HTTP server.

The configuration file is run through envsubst, so it can contain
any additional parameters as well. For example, a service account
key and a servicecontrol consumerId may be stored in a Kubernetes
secret and passed in as environment variables.