### PR TITLE
Report fields are lowercase, and the integer value is renamed to "int64Value"

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ sources:
     metric: instance-seconds
     intervalSeconds: 10
     value:
-      intValue: 10
+      int64Value: 10
     labels:
       auto: true
 ```
@@ -96,7 +96,7 @@ The agent provides a local HTTP instance for interaction with metered software.
 An example `curl` command to post a report:
 
 ```
-curl -X POST -d "{\"Name\": \"requests\", \"StartTime\": \"$(date -u +"%Y-%m-%dT%H:%M:%S.%NZ")\", \"EndTime\": \"$(date -u +"%Y-%m-%dT%H:%M:%S.%NZ")\", \"Value\": { \"IntValue\": 10 }, \"Labels\": { \"foo\": \"bar2\" } }" 'http://localhost:3456/report'
+curl -X POST -d "{\"name\": \"requests\", \"startTime\": \"$(date -u +"%Y-%m-%dT%H:%M:%S.%NZ")\", \"endTime\": \"$(date -u +"%Y-%m-%dT%H:%M:%S.%NZ")\", \"value\": { \"int64Value\": 10 }, \"labels\": { \"foo\": \"bar2\" } }" 'http://localhost:3456/report'
 ```
 
 The agent also provides status indicating its ability to send data to endpoints.

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -236,7 +236,7 @@ func (ar *aggregatedReport) accept(mr metrics.MetricReport) (bool, error) {
 	}
 	// Only one of these values should be non-zero. We rely on prior validation to ensure the proper
 	// value (i.e., the one specified in the metrics.Definition) is provided.
-	ar.Value.IntValue += mr.Value.IntValue
+	ar.Value.Int64Value += mr.Value.Int64Value
 	ar.Value.DoubleValue += mr.Value.DoubleValue
 
 	// The aggregated end time advances, but the start time remains unchanged.

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -42,7 +42,7 @@ func TestNewAggregator(t *testing.T) {
 			StartTime: time.Unix(0, 0),
 			EndTime:   time.Unix(1, 0),
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 			Labels: map[string]string{
 				"key": "value1",
@@ -54,7 +54,7 @@ func TestNewAggregator(t *testing.T) {
 			StartTime: time.Unix(10, 0),
 			EndTime:   time.Unix(11, 0),
 			Value: metrics.MetricValue{
-				IntValue: 333,
+				Int64Value: 333,
 			},
 			Labels: map[string]string{
 				"key": "value2",
@@ -66,7 +66,7 @@ func TestNewAggregator(t *testing.T) {
 			StartTime: time.Unix(100, 0),
 			EndTime:   time.Unix(110, 0),
 			Value: metrics.MetricValue{
-				IntValue: 555,
+				Int64Value: 555,
 			},
 			Labels: map[string]string{
 				"key": "value3",
@@ -171,7 +171,7 @@ func TestAggregator_AddReport(t *testing.T) {
 			StartTime: time.Unix(0, 0),
 			EndTime:   time.Unix(1, 0),
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 		}); err != nil {
 			t.Fatalf("Unexpected error when adding report: %+v", err)
@@ -186,7 +186,7 @@ func TestAggregator_AddReport(t *testing.T) {
 				StartTime: time.Unix(0, 0),
 				EndTime:   time.Unix(1, 0),
 				Value: metrics.MetricValue{
-					IntValue: 10,
+					Int64Value: 10,
 				},
 			},
 		}
@@ -209,7 +209,7 @@ func TestAggregator_AddReport(t *testing.T) {
 			StartTime: time.Unix(0, 0),
 			EndTime:   time.Unix(1, 0),
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 		}); err != nil {
 			t.Fatalf("Unexpected error when adding report: %+v", err)
@@ -219,7 +219,7 @@ func TestAggregator_AddReport(t *testing.T) {
 			StartTime: time.Unix(2, 0),
 			EndTime:   time.Unix(3, 0),
 			Value: metrics.MetricValue{
-				IntValue: 5,
+				Int64Value: 5,
 			},
 		}); err != nil {
 			t.Fatalf("Unexpected error when adding report: %+v", err)
@@ -234,7 +234,7 @@ func TestAggregator_AddReport(t *testing.T) {
 				StartTime: time.Unix(0, 0),
 				EndTime:   time.Unix(3, 0),
 				Value: metrics.MetricValue{
-					IntValue: 15,
+					Int64Value: 15,
 				},
 			},
 		}
@@ -260,7 +260,7 @@ func TestAggregator_AddReport(t *testing.T) {
 				"key1": "value1",
 			},
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 		}); err != nil {
 			t.Fatalf("Unexpected error when adding report: %+v", err)
@@ -273,7 +273,7 @@ func TestAggregator_AddReport(t *testing.T) {
 				"key1": "value2",
 			},
 			Value: metrics.MetricValue{
-				IntValue: 5,
+				Int64Value: 5,
 			},
 		}); err != nil {
 			t.Fatalf("Unexpected error when adding report: %+v", err)
@@ -291,7 +291,7 @@ func TestAggregator_AddReport(t *testing.T) {
 					"key1": "value1",
 				},
 				Value: metrics.MetricValue{
-					IntValue: 10,
+					Int64Value: 10,
 				},
 			},
 			{
@@ -302,7 +302,7 @@ func TestAggregator_AddReport(t *testing.T) {
 					"key1": "value2",
 				},
 				Value: metrics.MetricValue{
-					IntValue: 5,
+					Int64Value: 5,
 				},
 			},
 		}
@@ -328,7 +328,7 @@ func TestAggregator_AddReport(t *testing.T) {
 				"key1": "value1",
 			},
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 		}); err == nil || !strings.Contains(err.Error(), "StartTime > EndTime") {
 			t.Fatalf("Expected error containing \"StartTime > EndTime\", got: %+v", err.Error())
@@ -347,7 +347,7 @@ func TestAggregator_AddReport(t *testing.T) {
 			StartTime: time.Unix(0, 0),
 			EndTime:   time.Unix(1, 0),
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 		}); err != nil {
 			t.Fatalf("Unexpected error when adding report: %+v", err)
@@ -357,7 +357,7 @@ func TestAggregator_AddReport(t *testing.T) {
 			StartTime: time.Unix(0, 0),
 			EndTime:   time.Unix(2, 0),
 			Value: metrics.MetricValue{
-				IntValue: 5,
+				Int64Value: 5,
 			},
 		}); err == nil || !strings.Contains(err.Error(), "time conflict") {
 			t.Fatalf("Expected error containing \"time conflict\", got: %+v", err)
@@ -376,7 +376,7 @@ func TestAggregator_AddReport(t *testing.T) {
 			StartTime: time.Unix(0, 0),
 			EndTime:   time.Unix(1, 0),
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 		}); err != nil {
 			t.Fatalf("Unexpected error when adding report: %+v", err)
@@ -386,7 +386,7 @@ func TestAggregator_AddReport(t *testing.T) {
 			StartTime: time.Unix(2, 0),
 			EndTime:   time.Unix(3, 0),
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 			Labels: map[string]string{
 				"foo": "bar",
@@ -409,7 +409,7 @@ func TestAggregator_AddReport(t *testing.T) {
 			StartTime: time.Unix(4, 0),
 			EndTime:   time.Unix(5, 0),
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 		}); err != nil {
 			t.Fatalf("Unexpected error when adding report: %+v", err)
@@ -419,7 +419,7 @@ func TestAggregator_AddReport(t *testing.T) {
 			StartTime: time.Unix(6, 0),
 			EndTime:   time.Unix(7, 0),
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 			Labels: map[string]string{
 				"foo": "bar",
@@ -450,7 +450,7 @@ func TestAggregator_AddReport(t *testing.T) {
 			StartTime: time.Unix(0, 0),
 			EndTime:   time.Unix(1, 0),
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 		}); err != nil {
 			t.Fatalf("Unexpected error when adding report: %+v", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -89,7 +89,7 @@ sources:
     metric: int-metric
     intervalSeconds: 10
     value:
-      intValue: 10
+      int64Value: 10
     labels:
       foo: bar
 `
@@ -164,7 +164,7 @@ sources:
 					Metric:          "int-metric",
 					IntervalSeconds: 10,
 					Value: metrics.MetricValue{
-						IntValue: 10,
+						Int64Value: 10,
 					},
 					Labels: map[string]string{"foo": "bar"},
 				},

--- a/config/sources_test.go
+++ b/config/sources_test.go
@@ -50,7 +50,7 @@ func TestSources_Validate(t *testing.T) {
 		Metric:          "int-metric",
 		IntervalSeconds: 10,
 		Value: metrics.MetricValue{
-			IntValue: 10,
+			Int64Value: 10,
 		},
 	}
 
@@ -89,7 +89,7 @@ func TestSources_Validate(t *testing.T) {
 						Metric:          "int-metric",
 						IntervalSeconds: c.val,
 						Value: metrics.MetricValue{
-							IntValue: 10,
+							Int64Value: 10,
 						},
 					},
 				},
@@ -112,7 +112,7 @@ func TestSources_Validate(t *testing.T) {
 				Metric:          "int-metric",
 				IntervalSeconds: 10,
 				Value: metrics.MetricValue{
-					IntValue: 10,
+					Int64Value: 10,
 				},
 			},
 		}

--- a/endpoint/disk/disk_test.go
+++ b/endpoint/disk/disk_test.go
@@ -51,7 +51,7 @@ func TestDiskEndpoint(t *testing.T) {
 			StartTime: time.Unix(0, 0),
 			EndTime:   time.Unix(1, 0),
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 		},
 	})
@@ -75,7 +75,7 @@ func TestDiskEndpoint(t *testing.T) {
 			StartTime: time.Unix(2, 0),
 			EndTime:   time.Unix(3, 0),
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 		},
 	})

--- a/endpoint/servicecontrol/servicecontrol.go
+++ b/endpoint/servicecontrol/servicecontrol.go
@@ -109,8 +109,8 @@ func (ep *ServiceControlEndpoint) format(r endpoint.EndpointReport) *servicecont
 		StartTime: r.StartTime.UTC().Format(time.RFC3339Nano),
 		EndTime:   r.EndTime.UTC().Format(time.RFC3339Nano),
 	}
-	if r.Value.IntValue != 0 {
-		value.Int64Value = &r.Value.IntValue
+	if r.Value.Int64Value != 0 {
+		value.Int64Value = &r.Value.Int64Value
 	} else if r.Value.DoubleValue != 0 {
 		value.DoubleValue = &r.Value.DoubleValue
 	}

--- a/endpoint/servicecontrol/servicecontrol_test.go
+++ b/endpoint/servicecontrol/servicecontrol_test.go
@@ -73,7 +73,7 @@ func TestServiceControlEndpoint(t *testing.T) {
 				StartTime: time.Unix(0, 0),
 				EndTime:   time.Unix(1, 0),
 				Value: metrics.MetricValue{
-					IntValue: 10,
+					Int64Value: 10,
 				},
 			},
 		})

--- a/metrics/report.go
+++ b/metrics/report.go
@@ -24,8 +24,8 @@ import (
 // MetricValue holds a single named metric value. Only one of the individual type fields should
 // be non-zero.
 type MetricValue struct {
-	IntValue    int64
-	DoubleValue float64
+	Int64Value  int64   `json:"int64Value"`
+	DoubleValue float64 `json:"doubleValue"`
 }
 
 func (mv MetricValue) Validate(def Definition) error {
@@ -36,8 +36,8 @@ func (mv MetricValue) Validate(def Definition) error {
 		}
 		break
 	case DoubleType:
-		if mv.IntValue != 0 {
-			return fmt.Errorf("integer value specified for double metric: %v", mv.IntValue)
+		if mv.Int64Value != 0 {
+			return fmt.Errorf("integer value specified for double metric: %v", mv.Int64Value)
 		}
 		break
 	}
@@ -46,11 +46,11 @@ func (mv MetricValue) Validate(def Definition) error {
 
 // Report represents an aggregated interval for a unique metric + labels combination.
 type MetricReport struct {
-	Name      string
-	StartTime time.Time
-	EndTime   time.Time
-	Labels    map[string]string
-	Value     MetricValue
+	Name      string            `json:"name"`
+	StartTime time.Time         `json:"startTime"`
+	EndTime   time.Time         `json:"endTime"`
+	Labels    map[string]string `json:"labels"`
+	Value     MetricValue       `json:"value"`
 }
 
 func (mr MetricReport) Validate(def Definition) error {

--- a/metrics/report_test.go
+++ b/metrics/report_test.go
@@ -39,7 +39,7 @@ func TestMetricReport_Validate(t *testing.T) {
 			EndTime:   time.Unix(1, 0),
 			Labels:    map[string]string{"Key": "Value"},
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 		}
 		if err := m.Validate(int_metric); err != nil {
@@ -54,7 +54,7 @@ func TestMetricReport_Validate(t *testing.T) {
 			EndTime:   time.Unix(1, 0),
 			Labels:    map[string]string{"Key": "Value"},
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 		}
 		if err := m.Validate(int_metric); err == nil || err.Error() != "incorrect metric name: foo" {
@@ -69,7 +69,7 @@ func TestMetricReport_Validate(t *testing.T) {
 			EndTime:   time.Unix(1, 0),
 			Labels:    map[string]string{"Key": "Value"},
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 		}
 		if err := m.Validate(int_metric); err == nil || !strings.Contains(err.Error(), "StartTime > EndTime") {
@@ -99,7 +99,7 @@ func TestMetricReport_Validate(t *testing.T) {
 			EndTime:   time.Unix(1, 0),
 			Labels:    map[string]string{"Key": "Value"},
 			Value: metrics.MetricValue{
-				IntValue: 10,
+				Int64Value: 10,
 			},
 		}
 		if err := m.Validate(double_metric); err == nil || !strings.Contains(err.Error(), "integer value specified") {

--- a/pipeline/builder/builder_test.go
+++ b/pipeline/builder/builder_test.go
@@ -81,7 +81,7 @@ func TestBuild(t *testing.T) {
 					Metric:          "int-metric",
 					IntervalSeconds: 10,
 					Value: metrics.MetricValue{
-						IntValue: 10,
+						Int64Value: 10,
 					},
 					Labels: map[string]string{"foo": "bar"},
 				},

--- a/pipeline/inputs_test.go
+++ b/pipeline/inputs_test.go
@@ -34,7 +34,7 @@ func TestSelector(t *testing.T) {
 		StartTime: time.Unix(10, 0),
 		EndTime:   time.Unix(11, 0),
 		Value: metrics.MetricValue{
-			IntValue: 1,
+			Int64Value: 1,
 		},
 	}
 
@@ -43,7 +43,7 @@ func TestSelector(t *testing.T) {
 		StartTime: time.Unix(10, 0),
 		EndTime:   time.Unix(11, 0),
 		Value: metrics.MetricValue{
-			IntValue: 1,
+			Int64Value: 1,
 		},
 	}
 
@@ -52,7 +52,7 @@ func TestSelector(t *testing.T) {
 		StartTime: time.Unix(10, 0),
 		EndTime:   time.Unix(11, 0),
 		Value: metrics.MetricValue{
-			IntValue: 1,
+			Int64Value: 1,
 		},
 	}
 
@@ -143,7 +143,7 @@ func TestCallbackInput(t *testing.T) {
 		StartTime: time.Unix(10, 0),
 		EndTime:   time.Unix(11, 0),
 		Value: metrics.MetricValue{
-			IntValue: 1,
+			Int64Value: 1,
 		},
 	}
 

--- a/sender/dispatcher_test.go
+++ b/sender/dispatcher_test.go
@@ -32,7 +32,7 @@ func TestDispatcher(t *testing.T) {
 		Id: "report",
 		MetricReport: metrics.MetricReport{
 			Name:      "int-metric",
-			Value:     metrics.MetricValue{IntValue: 30},
+			Value:     metrics.MetricValue{Int64Value: 30},
 			StartTime: time.Unix(10, 0),
 			EndTime:   time.Unix(11, 0),
 		},
@@ -116,7 +116,7 @@ func TestDispatcher(t *testing.T) {
 				StartTime: time.Unix(0, 0),
 				EndTime:   time.Unix(1, 0),
 				Value: metrics.MetricValue{
-					IntValue: 10,
+					Int64Value: 10,
 				},
 			},
 		}

--- a/sender/retry_test.go
+++ b/sender/retry_test.go
@@ -36,7 +36,7 @@ func TestRetryingSender(t *testing.T) {
 		Id: "report1",
 		MetricReport: metrics.MetricReport{
 			Name:      "int-metric",
-			Value:     metrics.MetricValue{IntValue: 10},
+			Value:     metrics.MetricValue{Int64Value: 10},
 			StartTime: time.Unix(0, 0),
 			EndTime:   time.Unix(1, 0),
 		},
@@ -45,7 +45,7 @@ func TestRetryingSender(t *testing.T) {
 		Id: "report2",
 		MetricReport: metrics.MetricReport{
 			Name:      "int-metric",
-			Value:     metrics.MetricValue{IntValue: 30},
+			Value:     metrics.MetricValue{Int64Value: 30},
 			StartTime: time.Unix(10, 0),
 			EndTime:   time.Unix(11, 0),
 		},
@@ -54,7 +54,7 @@ func TestRetryingSender(t *testing.T) {
 		Id: "report3",
 		MetricReport: metrics.MetricReport{
 			Name:      "int-metric",
-			Value:     metrics.MetricValue{IntValue: 30},
+			Value:     metrics.MetricValue{Int64Value: 30},
 			StartTime: time.Unix(20, 0),
 			EndTime:   time.Unix(21, 0),
 		},

--- a/source/heartbeat_test.go
+++ b/source/heartbeat_test.go
@@ -31,7 +31,7 @@ func TestHeartbeat(t *testing.T) {
 		Metric:          "instanceSeconds",
 		IntervalSeconds: 10,
 		Value: metrics.MetricValue{
-			IntValue: 10,
+			Int64Value: 10,
 		},
 		Labels: map[string]string{
 			"foo": "bar",


### PR DESCRIPTION
Small changes to make the agent's report message look more similar to that of Service Control.
