### PR TITLE
Fixes a couple of build issues.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY . /ubbagent-src/
 WORKDIR /ubbagent-src/
 
 RUN apk add --no-cache make git
+RUN rm -rf /ubbagent-src/.git
 RUN make clean setup deps build
 
 FROM alpine:3.7

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMPORT_PATH := github.com/GoogleCloudPlatform/ubbagent
 # V := 1 # When V is set, print commands and build progress.
 
 # Space separated patterns of packages to skip in list, test, format.
-IGNORED_PACKAGES := /vendor/
+IGNORED_PACKAGES := /vendor/ /sdk/python2
 
 .PHONY: all
 all: help
@@ -123,9 +123,8 @@ setup: clean .GOPATH/.ok
 	@test -f Gopkg.toml || \
 		(cd $(CURDIR)/.GOPATH/src/$(IMPORT_PATH) && ./bin/dep init)
 
-VERSION          := $(shell git describe --tags --always --dirty="-dev")
 DATE             := $(shell date -u '+%Y-%m-%d-%H%M UTC')
-VERSION_FLAGS    := -ldflags='-X "main.Version=$(VERSION)" -X "main.BuildTime=$(DATE)"'
+VERSION_FLAGS    := -ldflags='-X "main.BuildTime=$(DATE)"'
 
 # cd into the GOPATH to workaround ./... not following symlinks
 _allpackages = $(shell ( cd $(CURDIR)/.GOPATH/src/$(IMPORT_PATH) && \


### PR DESCRIPTION
`make test` was broken due to the sdk/python2 directory. Specifically,
'go vet' complained that there were no Go files here. Not to clear on
what causes the problem, so for now I've just added this package to the
list of ignored packages.

Docker builds no longer depend on the ubbagent directory being a valid Git repo.