### PR TITLE
Expand both StartTime and EndTime when receiving new reports.

### DIFF
--- a/pipeline/inputs/aggregator.go
+++ b/pipeline/inputs/aggregator.go
@@ -222,15 +222,10 @@ type bucket struct {
 type aggregatedReport metrics.MetricReport
 
 // accept possibly aggregates the given MetricReport into this aggregatedReport. Returns true
-// if the report was aggregated, or false if the labels or name don't match. Returns an error if the
-// given report could be aggregated (i.e., labels match), but has earlier end time than the
-// aggregated end time.
+// if the report was aggregated, or false if the labels or name don't match.
 func (ar *aggregatedReport) accept(mr metrics.MetricReport) (bool, error) {
 	if mr.Name != ar.Name || !reflect.DeepEqual(mr.Labels, ar.Labels) {
 		return false, nil
-	}
-	if mr.EndTime.Before(ar.EndTime) {
-		return false, fmt.Errorf("time conflict: %v < %v", mr.EndTime, ar.EndTime)
 	}
 	// Only one of these values should be non-zero. We rely on prior validation to ensure the proper
 	// value (i.e., the one specified in the metrics.Definition) is provided.
@@ -240,8 +235,10 @@ func (ar *aggregatedReport) accept(mr metrics.MetricReport) (bool, error) {
 	if mr.StartTime.Before(ar.StartTime) {
 		ar.StartTime = mr.StartTime
 	}
-	// The aggregated end time advances.
-	ar.EndTime = mr.EndTime
+	// Expand the aggregated end time if the given MetricReport has later end time.
+	if mr.EndTime.After(ar.StartTime) {
+		ar.EndTime = mr.EndTime
+	}
 	return true, nil
 }
 

--- a/pipeline/inputs/aggregator_test.go
+++ b/pipeline/inputs/aggregator_test.go
@@ -333,7 +333,7 @@ func TestAggregator_AddReport(t *testing.T) {
 		}
 	})
 
-	// Add a report with a start time less than the last end time, testing aggregation
+	// Add reports to expand start time and end time, testing aggregation
 	t.Run("Time conflict", func(t *testing.T) {
 		mockClock := testlib.NewMockClock()
 		mockClock.SetNow(time.Unix(0, 0))
@@ -342,8 +342,8 @@ func TestAggregator_AddReport(t *testing.T) {
 
 		if err := a.AddReport(metrics.MetricReport{
 			Name:      "int-metric",
-			StartTime: time.Unix(0, 0),
-			EndTime:   time.Unix(2, 0),
+			StartTime: time.Unix(1, 0),
+			EndTime:   time.Unix(3, 0),
 			Value: metrics.MetricValue{
 				Int64Value: 10,
 			},
@@ -352,10 +352,20 @@ func TestAggregator_AddReport(t *testing.T) {
 		}
 		if err := a.AddReport(metrics.MetricReport{
 			Name:      "int-metric",
-			StartTime: time.Unix(1, 0),
+			StartTime: time.Unix(0, 0),
 			EndTime:   time.Unix(3, 0),
 			Value: metrics.MetricValue{
 				Int64Value: 5,
+			},
+		}); err != nil {
+			t.Fatalf("Unexpected error when adding report: %+v", err)
+		}
+		if err := a.AddReport(metrics.MetricReport{
+			Name:      "int-metric",
+			StartTime: time.Unix(2, 0),
+			EndTime:   time.Unix(4, 0),
+			Value: metrics.MetricValue{
+				Int64Value: 7,
 			},
 		}); err != nil {
 			t.Fatalf("Unexpected error when adding report: %+v", err)
@@ -368,9 +378,9 @@ func TestAggregator_AddReport(t *testing.T) {
 			{
 				Name:      "int-metric",
 				StartTime: time.Unix(0, 0),
-				EndTime:   time.Unix(3, 0),
+				EndTime:   time.Unix(4, 0),
 				Value: metrics.MetricValue{
-					Int64Value: 15,
+					Int64Value: 22,
 				},
 			},
 		}

--- a/pipeline/inputs/aggregator_test.go
+++ b/pipeline/inputs/aggregator_test.go
@@ -333,7 +333,7 @@ func TestAggregator_AddReport(t *testing.T) {
 		}
 	})
 
-	// Add a report with a start time less than the last end time: error
+	// Add a report with a start time less than the last end time, testing aggregation
 	t.Run("Time conflict", func(t *testing.T) {
 		mockClock := testlib.NewMockClock()
 		mockClock.SetNow(time.Unix(0, 0))
@@ -343,7 +343,7 @@ func TestAggregator_AddReport(t *testing.T) {
 		if err := a.AddReport(metrics.MetricReport{
 			Name:      "int-metric",
 			StartTime: time.Unix(0, 0),
-			EndTime:   time.Unix(1, 0),
+			EndTime:   time.Unix(2, 0),
 			Value: metrics.MetricValue{
 				Int64Value: 10,
 			},
@@ -352,13 +352,32 @@ func TestAggregator_AddReport(t *testing.T) {
 		}
 		if err := a.AddReport(metrics.MetricReport{
 			Name:      "int-metric",
-			StartTime: time.Unix(0, 0),
-			EndTime:   time.Unix(2, 0),
+			StartTime: time.Unix(1, 0),
+			EndTime:   time.Unix(3, 0),
 			Value: metrics.MetricValue{
 				Int64Value: 5,
 			},
-		}); err == nil || !strings.Contains(err.Error(), "time conflict") {
-			t.Fatalf("Expected error containing \"time conflict\", got: %+v", err)
+		}); err != nil {
+			t.Fatalf("Unexpected error when adding report: %+v", err)
+		}
+		mi.DoAndWait(t, 1, func() {
+			mockClock.SetNow(time.Unix(100, 0))
+		})
+
+		expected := []metrics.MetricReport{
+			{
+				Name:      "int-metric",
+				StartTime: time.Unix(0, 0),
+				EndTime:   time.Unix(3, 0),
+				Value: metrics.MetricValue{
+					Int64Value: 15,
+				},
+			},
+		}
+
+		reports := mi.Reports()
+		if !equalUnordered(reports, expected) {
+			t.Fatalf("Aggregated reports: expected: %+v, got: %+v", expected, reports)
 		}
 	})
 


### PR DESCRIPTION
Background: usage reports may have overlap time range when several clients send requests concurrently. When the ubbagent receive new reports, it should allow reports with time range already within the StartTime and EndTime range.