### PR TITLE
Handle case where file is empty

### DIFF
--- a/persistence/disk.go
+++ b/persistence/disk.go
@@ -61,6 +61,9 @@ func (v *diskValue) load(obj interface{}) error {
 	if err != nil {
 		return err
 	}
+	if len(jsontext) == 0 {
+		return ErrNotFound
+	}
 	err = json.Unmarshal(jsontext, obj)
 	if err != nil {
 		return err

--- a/persistence/disk_test.go
+++ b/persistence/disk_test.go
@@ -1,0 +1,43 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package persistence
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+type emptyStruct struct{}
+
+func TestEmptyFile(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "disk_endpoint_test")
+	if err != nil {
+		t.Fatalf("Unable to create temp directory: %+v", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	ioutil.WriteFile(path.Join(tmpdir, "empty.json"), []byte{}, 0644)
+	p, err := NewDiskPersistence(tmpdir)
+	if err != nil {
+		t.Fatalf("Unable to create new DiskPersistence")
+	}
+	v := emptyStruct{}
+	err = p.Value("empty").Load(&v)
+	if err != ErrNotFound {
+		t.Fatalf("Expected NotFound error but found %+v", err)
+	}
+}


### PR DESCRIPTION
Fix #55.

It's not totally clear why the persistent file would be empty. One possible reason indicated in the issue is when the process gets terminated before the write is fully flushed, in which case a data loss has occurred.

Looking at the code, that write operation is already as atomic as it could get. Handling the panic is at least better for now.