### PR TITLE
Make disk use a memory cache

### DIFF
--- a/config/filters_test.go
+++ b/config/filters_test.go
@@ -17,9 +17,10 @@ package config_test
 import (
 	"testing"
 
+	"reflect"
+
 	"github.com/GoogleCloudPlatform/ubbagent/config"
 	"github.com/GoogleCloudPlatform/ubbagent/metrics"
-	"reflect"
 )
 
 func TestFilters_Validate(t *testing.T) {

--- a/persistence/disk_test.go
+++ b/persistence/disk_test.go
@@ -18,10 +18,13 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"reflect"
 	"testing"
 )
 
-type emptyStruct struct{}
+type testStruct struct {
+	Value int
+}
 
 func TestEmptyFile(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "disk_endpoint_test")
@@ -30,14 +33,92 @@ func TestEmptyFile(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 
+	// Make sure that it starts clean, and a newly stored data can be retrieved.
+	testBrandNewDiskPersistenceCanStoreAndRetrieve(t, tmpdir, "empty", testStruct{Value: 10})
+
+	// Overwrite the state file to an empty file.
 	ioutil.WriteFile(path.Join(tmpdir, "empty.json"), []byte{}, 0644)
 	p, err := NewDiskPersistence(tmpdir)
 	if err != nil {
 		t.Fatalf("Unable to create new DiskPersistence")
 	}
-	v := emptyStruct{}
+	var v testStruct
 	err = p.Value("empty").Load(&v)
+	// If we wrote the wrong file, the error would be nil.
+	// If the library couldn't handle empty file, the error wouldn't be ErrNotFound.
 	if err != ErrNotFound {
 		t.Fatalf("Expected NotFound error but found %+v", err)
 	}
+}
+
+func TestFileExternallyModified(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "disk_endpoint_test")
+	if err != nil {
+		t.Fatalf("Unable to create temp directory: %+v", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	// Make sure that it starts clean, and a newly stored data can be retrieved.
+	expectedValue := testStruct{Value: 10}
+	p := testBrandNewDiskPersistenceCanStoreAndRetrieve(t, tmpdir, "empty", expectedValue)
+
+	// Overwrite the state file to an empty file. Since we still use the same
+	// persistence object, this shouldn't affect its memory.
+	ioutil.WriteFile(path.Join(tmpdir, "empty.json"), []byte{}, 0644)
+	var actualValue testStruct
+	err = p.Value("empty").Load(&actualValue)
+	if err != nil {
+		t.Fatalf("Unexpected error %+v", err)
+	}
+	if !reflect.DeepEqual(expectedValue, actualValue) {
+		t.Fatalf("Loaded value is %+v while expecting %+v", actualValue, expectedValue)
+	}
+}
+
+func TestRestoredFromFile(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "disk_endpoint_test")
+	if err != nil {
+		t.Fatalf("Unable to create temp directory: %+v", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	expectedValue := testStruct{Value: 10}
+	testBrandNewDiskPersistenceCanStoreAndRetrieve(t, tmpdir, "key", expectedValue)
+
+	p, err := NewDiskPersistence(tmpdir)
+	if err != nil {
+		t.Fatalf("Failed to recreate new disk persistenc %+v", err)
+	}
+	var actualValue testStruct
+	if err = p.Value("key").Load(&actualValue); err != nil {
+		t.Fatalf("Failed to load value %+v", err)
+	}
+	if !reflect.DeepEqual(expectedValue, actualValue) {
+		t.Fatalf("Loaded value is %+v while expecting a restored value of %+v", actualValue, expectedValue)
+	}
+}
+
+func testBrandNewDiskPersistenceCanStoreAndRetrieve(t *testing.T, tmpdir string, expectedKey string, expectedValue testStruct) (p Persistence) {
+	var actualValue testStruct
+
+	// Make sure that it starts clean, and a newly stored data can be retrieved.
+	p, err := NewDiskPersistence(tmpdir)
+	if err != nil {
+		t.Fatalf("Failed to create new disk persistenc %+v", err)
+	}
+	if err = p.Value(expectedKey).Load(&actualValue); err != ErrNotFound {
+		t.Fatalf("Expected NotFound error but found %+v", err)
+	}
+	if err = p.Value(expectedKey).Store(expectedValue); err != nil {
+		t.Fatalf("Failed to store value %+v", err)
+	}
+	actualValue.Value = 0
+	if err = p.Value(expectedKey).Load(&actualValue); err != nil {
+		t.Fatalf("Failed to load value %+v", err)
+	}
+	if !reflect.DeepEqual(expectedValue, actualValue) {
+		t.Fatalf("Loaded value is %+v while expecting %+v", actualValue, expectedValue)
+	}
+
+	return
 }

--- a/persistence/memory.go
+++ b/persistence/memory.go
@@ -28,17 +28,25 @@ type memoryPersistence struct {
 
 // NewMemoryPersistence constructs a new Persistence that stores objects in memory.
 func NewMemoryPersistence() Persistence {
+	return newMemoryPersistence()
+}
+
+func newMemoryPersistence() *memoryPersistence {
 	var mp memoryPersistence
 	mp.items = make(map[string][]byte)
 	return &mp
 }
 
 func (p *memoryPersistence) Value(name string) Value {
-	return &lockingValue{&memoryValue{p: p, name: name}}
+	return &lockingValue{p.value(name)}
 }
 
 func (p *memoryPersistence) Queue(name string) Queue {
-	return &valueQueue{&memoryValue{p: p, name: name}}
+	return &valueQueue{p.value(name)}
+}
+
+func (p *memoryPersistence) value(name string) *memoryValue {
+	return &memoryValue{p: p, name: name}
 }
 
 type memoryValue struct {

--- a/persistence/persistence_test.go
+++ b/persistence/persistence_test.go
@@ -53,6 +53,10 @@ func TestDiskPersistence(t *testing.T) {
 
 func testPersistence(p Persistence, t *testing.T) {
 	var input1 []Outer
+	var output1 []Outer
+	var output2 Outer
+	var output3 Outer
+
 	input1 = append(input1, Outer{
 		Value1: 0,
 		Value2: 10,
@@ -82,6 +86,11 @@ func testPersistence(p Persistence, t *testing.T) {
 		},
 	}
 
+	// Test non existent value.
+	if err := p.Value("test/input1").Load(&output1); err != ErrNotFound {
+		t.Fatalf("Expected ErrNotFound when loading removed input1, got: %+v", err)
+	}
+
 	if err := p.Value("test/input1").Store(input1); err != nil {
 		t.Fatalf("Unexpected error storing input1: %+v", err)
 	}
@@ -90,10 +99,6 @@ func testPersistence(p Persistence, t *testing.T) {
 	if err := p.Value("test/input2").Store(&input2); err != nil {
 		t.Fatalf("Unexpected error storing input2: %+v", err)
 	}
-
-	var output1 []Outer
-	var output2 Outer
-	var output3 Outer
 
 	if err := p.Value("test/input1").Load(&output1); err != nil {
 		t.Fatalf("Unexpected error loading input1: %+v", err)

--- a/pipeline/endpoint.go
+++ b/pipeline/endpoint.go
@@ -16,6 +16,7 @@ package pipeline
 
 import (
 	"encoding/json"
+
 	"github.com/GoogleCloudPlatform/ubbagent/metrics"
 )
 

--- a/pipeline/endpoints/servicecontrol_test.go
+++ b/pipeline/endpoints/servicecontrol_test.go
@@ -24,11 +24,12 @@ import (
 	"testing"
 	"time"
 
+	"strings"
+
 	"github.com/GoogleCloudPlatform/ubbagent/metrics"
 	"github.com/GoogleCloudPlatform/ubbagent/testlib"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/servicecontrol/v1"
-	"strings"
 )
 
 type recordingHandler struct {


### PR DESCRIPTION
This potentially fixes a problem where the persistent disk runs into issues, like the files getting removed or reset by the system.

This approach generally improves performance as we do not want to read from disk all the time.