### PR TITLE
Bump Go to 1.20

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,7 +21,7 @@ http_archive(
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
-go_register_toolchains(version = "1.19.9")
+go_register_toolchains(version = "1.20.4")
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/ubbagent
 
-go 1.19
+go 1.20
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
- Bumps Go to 1.20
~~- Updates Go dependencies (this fixes a couple of CVEs)~~