### PR TITLE
Update Go to 1.26.4 to resolve CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.3-alpine3.23 AS build
+FROM golang:1.26.4-alpine3.23 AS build
 
 RUN apk update && apk upgrade --no-cache
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,7 +47,7 @@ http_archive(
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
-go_register_toolchains(version = "1.26.3")
+go_register_toolchains(version = "1.26.4")
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")

--- a/cloudbuild.Dockerfile
+++ b/cloudbuild.Dockerfile
@@ -1,6 +1,6 @@
 # The image has the environment setup for running builds and tests
 # on Google Cloud Build.
 # use golang 1.26.3
-FROM golang:1.26.3-bookworm
+FROM golang:1.26.4-bookworm
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3-dev

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/ubbagent
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
Update Go to 1.26.4 to resolve CVE-2026-42504, CVE-2026-27145, and CVE-2026-42507