### PR TITLE
Tag both GCR and AR assets in tag rotation

### DIFF
--- a/cloudbuild-tag.yaml
+++ b/cloudbuild-tag.yaml
@@ -37,28 +37,57 @@ steps:
       exit 0
     fi
 
-    # Find the old image version currently tagged as public-image-*
-    OLD_PUBLIC_TAG=$(gcloud container images list-tags "gcr.io/$PROJECT_ID/metering/ubbagent" \
-      --filter="tags:public-image-*" --format="value(tags)" \
-      | tr ',' '\n' | grep '^public-image-' | head -n 1)
+    function rotate_public_tags() {
+      local gcr_image="$1"
+      local ar_image
+      ar_image=$(echo "$gcr_image" | sed -r 's|^gcr\.io/([^/]+)/(.*)$|us-docker.pkg.dev/\1/gcr.io/\2|')
 
-    if [[ -n "$OLD_PUBLIC_TAG" ]]; then
-      OLD_VERSION=${OLD_PUBLIC_TAG#public-image-}
-      OLD_DIGEST=$(gcloud container images list-tags "gcr.io/$PROJECT_ID/metering/ubbagent" \
-        --filter="tags:$OLD_PUBLIC_TAG" --format="value(digest)")
-      
-      echo "Found old public image version: $OLD_VERSION (digest: $OLD_DIGEST)"
-      
-      # Remove old public-image-$OLD_VERSION tag
-      gcloud container images untag "gcr.io/$PROJECT_ID/metering/ubbagent:$OLD_PUBLIC_TAG" --quiet
-      
-      # Add deprecated-public-image-$OLD_VERSION tag to the old digest
-      gcloud container images add-tag "gcr.io/$PROJECT_ID/metering/ubbagent@$OLD_DIGEST" "gcr.io/$PROJECT_ID/metering/ubbagent:deprecated-public-image-$OLD_VERSION" --quiet
-    fi
+      echo "Processing public tags for GCR image: $gcr_image"
+      echo "Processing public tags for AR image: $ar_image"
 
-    # Tag the new image ($TAG_NAME) locally and push it
-    docker tag gcr.io/$PROJECT_ID/metering/ubbagent:$TAG_NAME gcr.io/$PROJECT_ID/metering/ubbagent:public-image-$TAG_NAME
-    docker push gcr.io/$PROJECT_ID/metering/ubbagent:public-image-$TAG_NAME
+      # 1. Manage GCR Tags
+      local old_public_tag_gcr
+      old_public_tag_gcr=$(gcloud container images list-tags "$gcr_image" \
+        --filter="tags:public-image-*" --format="value(tags)" \
+        | tr ',' '\n' | grep '^public-image-' | head -n 1)
+
+      if [[ -n "$old_public_tag_gcr" ]]; then
+        local old_version_gcr="${old_public_tag_gcr#public-image-}"
+        local old_digest_gcr
+        old_digest_gcr=$(gcloud container images list-tags "$gcr_image" \
+          --filter="tags:$old_public_tag_gcr" --format="value(digest)")
+        
+        echo "[GCR] Found old public image version: $old_version_gcr (digest: $old_digest_gcr)"
+        gcloud container images untag "$gcr_image:$old_public_tag_gcr" --quiet
+        gcloud container images add-tag "$gcr_image@$old_digest_gcr" "$gcr_image:deprecated-public-image-$old_version_gcr" --quiet
+      fi
+
+      # Tag and push new version on GCR
+      docker tag "$gcr_image:$TAG_NAME" "$gcr_image:public-image-$TAG_NAME"
+      docker push "$gcr_image:public-image-$TAG_NAME"
+
+      # 2. Manage AR Tags
+      local tag_path version_path
+      if read -r tag_path version_path < <(gcloud artifacts docker tags list "$ar_image" --format="value(name,version)" \
+        | grep '/tags/public-image-' | head -n 1 || true); then
+        
+        if [[ -n "$tag_path" ]]; then
+          local old_public_tag_ar="${tag_path##*/tags/}"
+          local old_digest_ar="${version_path##*/versions/}"
+          local old_version_ar="${old_public_tag_ar#public-image-}"
+          
+          echo "[AR] Found old public image version: $old_version_ar (digest: $old_digest_ar)"
+          gcloud artifacts docker tags delete "$ar_image:$old_public_tag_ar" --quiet
+          gcloud artifacts docker tags add "$ar_image@$old_digest_ar" "$ar_image:deprecated-public-image-$old_version_ar" --quiet
+        fi
+      fi
+
+      # Tag and push new version on AR
+      docker tag "$gcr_image:$TAG_NAME" "$ar_image:public-image-$TAG_NAME"
+      docker push "$ar_image:public-image-$TAG_NAME"
+    }
+
+    rotate_public_tags "gcr.io/$PROJECT_ID/metering/ubbagent"
 
 - id: &DetermineShouldTagLatest Determine if images should be tagged latest
   name: gcr.io/cloud-builders/gcloud


### PR DESCRIPTION
This PR updates the public/deprecated tag rotation in cloudbuild-tag.yaml to apply tags to both GCR and Artifact Registry (AR) paths. This is required because security scanners treat GCR and AR image paths as separate assets, and applying deprecation tags to only GCR results in open vulnerability tracking bugs staying open on the AR asset (e.g. b/530973410).