### PR TITLE
Fix public image tag rotation digest error

### DIFF
--- a/cloudbuild-tag.yaml
+++ b/cloudbuild-tag.yaml
@@ -44,8 +44,8 @@ steps:
 
     if [[ -n "$OLD_PUBLIC_TAG" ]]; then
       OLD_VERSION=${OLD_PUBLIC_TAG#public-image-}
-      OLD_DIGEST=$(gcloud container images list-tags "gcr.io/$PROJECT_ID/metering/ubbagent" \
-        --filter="tags:$OLD_PUBLIC_TAG" --format="value(digest)")
+      OLD_DIGEST=$(gcloud container images describe "gcr.io/$PROJECT_ID/metering/ubbagent:$OLD_PUBLIC_TAG" \
+        --format="value(image_summary.digest)")
       
       echo "Found old public image version: $OLD_VERSION (digest: $OLD_DIGEST)"
       


### PR DESCRIPTION
### Issue
The GCB tag rotation step "Manage Public Image Tags" failed (or will fail) with the following error when rotating existing tags:
`ERROR: (gcloud.container.images.add-tag) [gcr.io/...@digest] digest must be of the form "sha256:<digest>".`

### Root Cause
The script was using `gcloud container images list-tags` to retrieve the digest of the old public image tag. However, `list-tags` truncates the digest to a 12-character short SHA by default. Even when using `--format="value(digest)"`, it returned the truncated value (e.g., `ad02c056f254`) without the required `sha256:` prefix. This truncated digest is invalid for the subsequent `add-tag` command.

### Proposed Fix & Justification
Replaced `gcloud container images list-tags` with `gcloud container images describe` to retrieve the digest of the specific old tag. 
Using `describe` with `--format="value(image_summary.digest)"` retrieves the full, untruncated 64-character SHA256 digest with the `sha256:` prefix, which is the correct format required by the `add-tag` command.

