### PR TITLE
Fix GCB 404 Not Found by refactoring to registry-side gcloud tagging

### DIFF
--- a/cloudbuild-tag.yaml
+++ b/cloudbuild-tag.yaml
@@ -13,15 +13,14 @@ substitutions:
 steps:
 
 - id: &PublishImages Publish Images
-  name: gcr.io/cloud-builders/docker
+  name: gcr.io/cloud-builders/gcloud
   waitFor:
   - '-'
   entrypoint: bash
   args:
   - -ceux
   - |
-    docker pull gcr.io/$_STAGING_PROJECT_ID/metering/ubbagent:sha_$COMMIT_SHA
-    docker tag gcr.io/$_STAGING_PROJECT_ID/metering/ubbagent:sha_$COMMIT_SHA gcr.io/$PROJECT_ID/metering/ubbagent:$TAG_NAME
+    gcloud container images add-tag "gcr.io/$_STAGING_PROJECT_ID/metering/ubbagent:sha_$COMMIT_SHA" "gcr.io/$PROJECT_ID/metering/ubbagent:$TAG_NAME" --quiet
 
 - id: Manage Public Image Tags
   name: gcr.io/cloud-builders/gcloud
@@ -69,7 +68,7 @@ steps:
   - echo "$(.cloudbuild/should_tag_latest.sh gcr.io/$PROJECT_ID/metering/ubbagent $TAG_NAME)" > should_tag_latest
 
 - id: Maybe tag images latest
-  name: gcr.io/cloud-builders/docker
+  name: gcr.io/cloud-builders/gcloud
   waitFor:
   - *DetermineShouldTagLatest
   entrypoint: /bin/bash
@@ -77,8 +76,7 @@ steps:
   - -ceux
   - |
     if [[ "$(cat should_tag_latest)" == "true" ]]; then
-      docker tag gcr.io/$PROJECT_ID/metering/ubbagent:$TAG_NAME gcr.io/$PROJECT_ID/metering/ubbagent:latest
-      docker push gcr.io/$PROJECT_ID/metering/ubbagent:latest
+      gcloud container images add-tag "gcr.io/$PROJECT_ID/metering/ubbagent:$TAG_NAME" "gcr.io/$PROJECT_ID/metering/ubbagent:latest" --quiet
     else
       echo "Not tagging latest"
     fi


### PR DESCRIPTION
### Issue
During the tag release GCB build, the "Manage Public Image Tags" step failed with a 404 "Not Found" error when attempting to add tags to the new image version.

### Root Cause
1. In Step 1 ("Publish Images"), we only tagged the image locally using `docker tag`. The image was not pushed to GCR at this stage.
2. In Step 2 ("Manage Public Image Tags"), we used `gcloud container images add-tag` to assign public tags to the new release.
3. Because `gcloud` operates registry-side and the new release image had not yet been pushed to the GCR registry, GCR returned a 404 error.

### Suggested Fix
Refactor the GCB configuration to use registry-side `gcloud` commands instead of local `docker` commands for all publishing and tagging steps:
1. In Step 1, replace `docker pull/tag` with `gcloud container images add-tag` to copy/publish the image from the staging registry to the production registry immediately.
2. In Step 4 ("Maybe tag images latest"), replace `docker tag/push` with `gcloud container images add-tag` for registry-side tagging.

### Why the Fix Works
* Publishing the image in Step 1 ensures it exists in the production GCR registry before Step 2 runs.
* Step 2's `gcloud add-tag` command will succeed because the source image is now present in the registry.
* Eliminating local Docker operations makes the build faster and avoids pulling large images to the runner.

