### PR TITLE
Fix GCB build failure by removing images section after gcloud refactor

### DIFF
--- a/cloudbuild-tag.yaml
+++ b/cloudbuild-tag.yaml
@@ -81,5 +81,3 @@ steps:
       echo "Not tagging latest"
     fi
 
-images:
-- gcr.io/$PROJECT_ID/metering/ubbagent:$TAG_NAME


### PR DESCRIPTION
### Issue
After refactoring the GCB tag release configuration to use registry-side `gcloud` tagging (to fix the 404 Not Found error), the build failed at the very end with the following error:
`ERROR: failed to find one or more images after execution of build steps`

### Root Cause
* The GCB configuration had an `images:` section listing the release image (`gcr.io/$PROJECT_ID/metering/ubbagent:$TAG_NAME`).
* GCB's native `images:` handler attempts to push this image from the runner's local Docker daemon at the end of the build.
* Because we switched to registry-side tagging using `gcloud` in Step 1, this image was never pulled locally.
* Since the image did not exist locally on the runner, GCB failed to find it for the automatic push step.

### Suggested Fix & Justification
Remove the `images:` section from `cloudbuild-tag.yaml`.
* **Justification:** Since the image is already copied and tagged directly in the production registry during Step 1 (`Publish Images`) using `gcloud`, GCB does not need to push it again. Removing this section prevents GCB from looking for local copies and allows the build to complete successfully. The only trade-off is that this image won't be listed in the GCB console's "Build Artifacts" metadata, but it is fully published and available in GCR.
